### PR TITLE
BUG: Limit CircleCI build parallelism

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,8 @@ jobs:
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
+          environment:
+            CTEST_BUILD_FLAGS: "-j5"
           command: |
             ctest -j 2 -VV -D Experimental
   package:

--- a/{{cookiecutter.project_name}}/.circleci/config.yml
+++ b/{{cookiecutter.project_name}}/.circleci/config.yml
@@ -19,6 +19,8 @@ jobs:
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
+          environment:
+            CTEST_BUILD_FLAGS: "-j5"
           command: |
             ctest -j 2 -VV -D Experimental
   package:


### PR DESCRIPTION
CircleCI systems have a large number of processors detected by ninja, but the
containers are provided with access to limited memory. This can cause builds
to fail when they run out of memory. Limit the number of parallel build
processes.