### PR TITLE
ENH: Use Makefile generator for ExternalProject

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,6 @@ jobs:
           name: Configure
           command: |
             cmake \
-              -G Ninja \
               -DITK_DIR:PATH=/ITK-build \
               -DBUILD_TESTING:BOOL=ON \
               -DBUILDNAME:STRING=External-ITKModuleTemplate-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM} \

--- a/{{cookiecutter.project_name}}/.circleci/config.yml
+++ b/{{cookiecutter.project_name}}/.circleci/config.yml
@@ -11,7 +11,6 @@ jobs:
           name: Configure
           command: |
             cmake \
-              -G Ninja \
               -DITK_DIR:PATH=/ITK-build \
               -DBUILD_TESTING:BOOL=ON \
               -DBUILDNAME:STRING=External-{{ cookiecutter.project_name }}-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM} \


### PR DESCRIPTION
Per the discussion in issue #15, use the default Unix Makefiles generator in
case an ExternalProject needs -j flags propagated.