### PR TITLE
ENH: Use CTest script for CircleCI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,33 +1,55 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: ~/ITKModuleTemplate-build
+    working_directory: /ITKModuleTemplate-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: ~/ITKModuleTemplateCookieCutter
+          path: /ITKModuleTemplateCookieCutter
+      - run:
+          name: Fetch CTest driver script
+          command: |
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
       - run:
           name: Evaluate template
           command: |
             python -m pip install cookiecutter
-            cd ~/
-            python -m cookiecutter --no-input ~/ITKModuleTemplateCookieCutter
+            cd /
+            python -m cookiecutter --no-input /ITKModuleTemplateCookieCutter
       - run:
-          name: Configure
+          name: Configure CTest script
           command: |
-            cmake \
-              -DITK_DIR:PATH=/ITK-build \
-              -DBUILD_TESTING:BOOL=ON \
-              -DBUILDNAME:STRING=External-ITKModuleTemplate-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM} \
-                ~/ITKModuleTemplate
+            SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
+
+            # Only for testing the template
+            mkdir -p /ITKModuleTemplate/.git
+
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-ITKModuleTemplate-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /ITKModuleTemplate)
+            set(CTEST_BINARY_DIRECTORY /ITKModuleTemplate-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+
+            # Only for testing the template
+            set(dashboard_no_update 1)
+
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
-          environment:
-            CTEST_BUILD_FLAGS: "-j5"
           command: |
-            ctest -j 2 -VV -D Experimental
+            ctest -j 2 -VV -S dashboard.cmake
   package:
     working_directory: ~/
     machine: true

--- a/{{cookiecutter.project_name}}/.circleci/config.yml
+++ b/{{cookiecutter.project_name}}/.circleci/config.yml
@@ -1,27 +1,41 @@
 version: 2
 jobs:
   build-and-test:
-    working_directory: ~/{{ cookiecutter.project_name }}-build
+    working_directory: /{{ cookiecutter.project_name }}-build
     docker:
       - image: insighttoolkit/module-ci:latest
     steps:
       - checkout:
-          path: ~/{{ cookiecutter.project_name }}
+          path: /{{ cookiecutter.project_name }}
       - run:
-          name: Configure
+          name: Fetch CTest driver script
           command: |
-            cmake \
-              -DITK_DIR:PATH=/ITK-build \
-              -DBUILD_TESTING:BOOL=ON \
-              -DBUILDNAME:STRING=External-{{ cookiecutter.project_name }}-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM} \
-                ~/{{ cookiecutter.project_name }}
+            curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITK/dashboard/itk_common.cmake -O
+      - run:
+          name: Configure CTest script
+          command: |
+            SHASNIP=$(echo $CIRCLE_SHA1 | cut -c1-7)
+            cat > dashboard.cmake << EOF
+            set(CTEST_SITE "CircleCI")
+            set(CTEST_BUILD_NAME "External-{{ cookiecutter.project_name }}-${CIRCLE_BRANCH}-${CIRCLE_BUILD_NUM}-${SHASNIP}")
+            set(CTEST_BUILD_CONFIGURATION "MinSizeRel")
+            set(CTEST_CMAKE_GENERATOR "Unix Makefiles")
+            set(CTEST_BUILD_FLAGS: "-j5")
+            set(CTEST_SOURCE_DIRECTORY /{{ cookiecutter.project_name }})
+            set(CTEST_BINARY_DIRECTORY /{{ cookiecutter.project_name }}-build)
+            set(dashboard_model Experimental)
+            set(dashboard_no_clean 1)
+            set(dashboard_cache "
+            ITK_DIR:PATH=/ITK-build
+            BUILD_TESTING:BOOL=ON
+            ")
+            include(\${CTEST_SCRIPT_DIRECTORY}/itk_common.cmake)
+            EOF
       - run:
           name: Build and Test
           no_output_timeout: 1.0h
-          environment:
-            CTEST_BUILD_FLAGS: "-j5"
           command: |
-            ctest -j 2 -VV -D Experimental
+            ctest -j 2 -VV -S dashboard.cmake
   package:
     working_directory: ~/{{ cookiecutter.project_name }}
     machine: true


### PR DESCRIPTION
This enables uploading of the revision to CTest in the update field and more
control over the CTest build configuration.