### PR TITLE
ENH: Use itk_module_add_library macro

### DIFF
--- a/{{cookiecutter.project_name}}/src/CMakeLists.txt
+++ b/{{cookiecutter.project_name}}/src/CMakeLists.txt
@@ -2,6 +2,4 @@ set({{ cookiecutter.module_name }}_SRCS
   itkMinimalStandardRandomVariateGenerator.cxx
   )
 
-add_library({{ cookiecutter.module_name }} ${{ '{' }}{{ cookiecutter.module_name }}_SRCS{{ '}' }})
-itk_module_link_dependencies()
-itk_module_target({{ cookiecutter.module_name}})
+itk_module_add_library({{ cookiecutter.module_name }} ${{ '{' }}{{ cookiecutter.module_name }}_SRCS{{ '}' }})


### PR DESCRIPTION
This newer macro is the simpler and preferred way to add libraries for
modules.