### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/{{cookiecutter.project_name}}/CMakeLists.txt
+++ b/{{cookiecutter.project_name}}/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10.2)
 project({{ cookiecutter.module_name }})
 
 set({{ cookiecutter.module_name }}_LIBRARIES {{ cookiecutter.module_name }})


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.