### PR TITLE
BUG: Use transfer.sh for macOS package upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
 - ./macpython-download-cache-and-build-module-wheels.sh
 - tar -zcvf dist.tar.gz dist/
-- curl -F file="@dist.tar.gz" https://file.io
+- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz

--- a/{{cookiecutter.project_name}}/.travis.yml
+++ b/{{cookiecutter.project_name}}/.travis.yml
@@ -12,4 +12,4 @@ script:
 - chmod u+x macpython-download-cache-and-build-module-wheels.sh
 - ./macpython-download-cache-and-build-module-wheels.sh
 - tar -zcvf dist.tar.gz dist/
-- curl -F file="@dist.tar.gz" https://file.io
+- curl --upload-file dist.tar.gz https://transfer.sh/dist.tar.gz


### PR DESCRIPTION
filebin.ca is no longer reliable.