### PR TITLE
DOC: Change reference to wiki for SWG reference.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Remote Module
 
 After an `Insight Journal <http://www.insight-journal.org/>`_ article has been
 submitted, the module can be included in ITK as a `remote module
-<http://www.itk.org/Wiki/ITK/Policy_and_Procedures_for_Adding_Remote_Modules>`_.
+<https://itk.org/ITKSoftwareGuide/html/Book1/ITKSoftwareGuide-Book1ch9.html#x55-1640009.7>`_.
 Add a file in "ITK/Modules/Remote" called "YourModule.remote.cmake", for this
 module it would be "ExternalExample.remote.cmake" with the followlowing
 contents::


### PR DESCRIPTION
Update the reference concerning the `Contributing with a Remote Module`
section: change the reference to the **wiki** for a reference to the **Software
Guide**. This part of the toolkit documentation was migrated to the SWG in
order to reduce the number of sites to look at when searching
documentation.