### PR TITLE
ENH: Use the `TRY_EXPECT_NO_EXCEPTION` macro in testing.

### DIFF
--- a/{{cookiecutter.project_name}}/test/itkNormalDistributionImageSourceTest.cxx
+++ b/{{cookiecutter.project_name}}/test/itkNormalDistributionImageSourceTest.cxx
@@ -52,15 +52,9 @@ int itkNormalDistributionImageSourceTest( int argc, char * argv[] )
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImageFileName );
   writer->SetInput( distributionSource->GetOutput() );
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error: " << error << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
   return EXIT_SUCCESS;
 }

--- a/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
+++ b/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
@@ -88,15 +88,9 @@ int itk{{cookiecutter.filter_name}}Test( int argc, char * argv[] )
   writer->SetFileName( outputImageFileName );
   writer->SetInput( filter->GetOutput() );
   writer->SetUseCompression(true);
-  try
-    {
-    writer->Update();
-    }
-  catch( itk::ExceptionObject & error )
-    {
-    std::cerr << "Error: " << error << std::endl;
-    return EXIT_FAILURE;
-    }
+
+  TRY_EXPECT_NO_EXCEPTION( writer->Update() );
+
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Use the `TRY_EXPECT_NO_EXCEPTION` macro to save typing/avoid boilerplate
code with `try/catch` block.