### PR TITLE
STYLE: Remove unnecessary white space before comma.

### DIFF
--- a/{{cookiecutter.project_name}}/test/itkNormalDistributionImageSourceTest.cxx
+++ b/{{cookiecutter.project_name}}/test/itkNormalDistributionImageSourceTest.cxx
@@ -39,7 +39,7 @@ int itkNormalDistributionImageSourceTest( int argc, char * argv[] )
   typedef itk::NormalDistributionImageSource< ImageType > DistributionSourceType;
   DistributionSourceType::Pointer distributionSource = DistributionSourceType::New();
 
-  EXERCISE_BASIC_OBJECT_METHODS( distributionSource, NormalDistributionImageSource , GenerateImageSource );
+  EXERCISE_BASIC_OBJECT_METHODS( distributionSource, NormalDistributionImageSource, GenerateImageSource );
 
 
   ImageType::SizeType size;


### PR DESCRIPTION
Remove unnecessary white space before comma in function argument list.