### PR TITLE
BUG: Fix NormalDistributionImageSource test

### DIFF
--- a/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.h
+++ b/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.h
@@ -70,7 +70,7 @@ protected:
 
   typedef typename ImageType::RegionType OutputRegionType;
 
-  virtual void DynamicThreadedGenerateData( const OutputRegionType & outputRegion ) ITK_OVERRIDE;
+  virtual void GenerateData() ITK_OVERRIDE;
 
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(NormalDistributionImageSource);

--- a/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.hxx
+++ b/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.hxx
@@ -45,9 +45,11 @@ NormalDistributionImageSource< TImage >
 template< typename TImage >
 void
 NormalDistributionImageSource< TImage >
-::DynamicThreadedGenerateData( const OutputRegionType & outputRegion )
+::GenerateData()
 {
+  this->AllocateOutputs();
   ImageType * output = this->GetOutput();
+  const OutputRegionType & outputRegion = output->GetRequestedRegion();
 
   typedef itk::Statistics::NormalVariateGenerator NormalGeneratorType;
   NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();


### PR DESCRIPTION
git bisect reveals that the test started failing with

  InsightSoftwareConsortium/ITK@4627a89f15e8cf6fc5f0fe6c3ff7e9221ce32db3

which is related to the number of work units used in the pool
multi-threader.

Simply consistent output generation by removing threading from the
example filter.