### PR TITLE
COMP: Use and move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
+++ b/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
@@ -54,6 +54,8 @@ class {{ cookiecutter.module_name }}_EXPORT MinimalStandardRandomVariateGenerato
   public RandomVariateGeneratorBase
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MinimalStandardRandomVariateGenerator);
+
   /** Standard class typedefs. */
   typedef MinimalStandardRandomVariateGenerator    Self;
   typedef RandomVariateGeneratorBase               Superclass;
@@ -83,7 +85,6 @@ protected:
   virtual void PrintSelf(std::ostream & os, Indent indent) const ITK_OVERRIDE;
 
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MinimalStandardRandomVariateGenerator);
 
   NormalGeneratorType::Pointer m_NormalGenerator;
 };


### PR DESCRIPTION
Use the `ITK_DISALLOW_COPY_AND_ASSIGN` macro to enhance consistency across
the the toolkit when disallowing the copy constructor and the assign
operator.

Move the `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/itk-disallow-copy-and-assign/648