### PR TITLE
STYLE: Prefer C++11 type alias over typedef.

### DIFF
--- a/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
+++ b/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
@@ -55,14 +55,14 @@ class {{ cookiecutter.module_name }}_EXPORT MinimalStandardRandomVariateGenerato
 {
 public:
   /** Standard class typedefs. */
-  typedef MinimalStandardRandomVariateGenerator    Self;
-  typedef RandomVariateGeneratorBase               Superclass;
-  typedef SmartPointer< Self >                     Pointer;
-  typedef SmartPointer< const Self >               ConstPointer;
+  using Self = MinimalStandardRandomVariateGenerator;
+  using Superclass = RandomVariateGeneratorBase;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
-  typedef uint32_t IntegerType;
+  using IntegerType = uint32_t;
 
-  typedef itk::Statistics::NormalVariateGenerator NormalGeneratorType;
+  using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
 
   /** Run-time type information (and related methods). */
   itkTypeMacro( MinimalStandardRandomVariateGenerator, RandomVariateGeneratorBase);

--- a/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.hxx
+++ b/{{cookiecutter.project_name}}/include/itkNormalDistributionImageSource.hxx
@@ -51,7 +51,7 @@ NormalDistributionImageSource< TImage >
   ImageType * output = this->GetOutput();
   const OutputRegionType & outputRegion = output->GetRequestedRegion();
 
-  typedef itk::Statistics::NormalVariateGenerator NormalGeneratorType;
+  using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
   NormalGeneratorType::Pointer normalGenerator = NormalGeneratorType::New();
   normalGenerator->Initialize( 101 );
 
@@ -62,7 +62,7 @@ NormalDistributionImageSource< TImage >
     }
   const SizeValueType numberOfLinesToProcess = outputRegion.GetNumberOfPixels() / size0;
 
-  typedef ImageScanlineIterator< ImageType > IteratorType;
+  using IteratorType = ImageScanlineIterator< ImageType >;
   IteratorType it( output, outputRegion );
 
   while( !it.IsAtEnd() )

--- a/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
+++ b/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
@@ -65,7 +65,7 @@ protected:
 
   void PrintSelf( std::ostream& os, Indent indent ) const override;
 
-  typedef typename OutputImageType::RegionType OutputRegionType;
+  using OutputRegionType = typename OutputImageType::RegionType;
 
   virtual void DynamicThreadedGenerateData( const OutputRegionType & outputRegion) override;
 


### PR DESCRIPTION
Prefer C++11 type alias over `typedef` for the reasons stated here:
http://review.source.kitware.com/#/c/23103/