### PR TITLE
STYLE: Pefer = default to explicitly trivial implementations.

### DIFF
--- a/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
+++ b/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
@@ -80,7 +80,7 @@ public:
 
 protected:
   MinimalStandardRandomVariateGenerator();
-  virtual ~MinimalStandardRandomVariateGenerator() {}
+  ~MinimalStandardRandomVariateGenerator() override = default;
 
   void PrintSelf(std::ostream & os, Indent indent) const override;
 

--- a/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
+++ b/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
@@ -61,7 +61,7 @@ public:
 
 protected:
   {{ cookiecutter.filter_name }}();
-  virtual ~{{ cookiecutter.filter_name }}() override {}
+  ~{{ cookiecutter.filter_name }}() override = default;
 
   void PrintSelf( std::ostream& os, Indent indent ) const override;
 


### PR DESCRIPTION
This check replaces default bodies of special member functions with
= default;. The explicitly defaulted function declarations enable more
opportunities in optimization, because the compiler might treat
explicitly defaulted functions as trivial.

Additionally, the C++11 use of = default more clearly expreses the
intent for the special member functions.