### PR TITLE
ENH: Use the `itkNameOfTestExecutableMacro` to get the test name

### DIFF
--- a/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
+++ b/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
@@ -56,7 +56,7 @@ int itk{{cookiecutter.filter_name}}Test( int argc, char * argv[] )
   if( argc < 2 )
     {
     std::cerr << "Missing parameters." << std::endl;
-    std::cerr << "Usage: " << argv[0];
+    std::cerr << "Usage: " << itkNameOfTestExecutableMacro(argv);
     std::cerr << " outputImage";
     std::cerr << std::endl;
     return EXIT_FAILURE;


### PR DESCRIPTION
Use the `itkNameOfTestExecutableMacro` to get the test name and prevent
the the test from crashing when `argv[0]` is null, as recommended in:
https://github.com/InsightSoftwareConsortium/ITK/pull/564