### PR TITLE
ENH: Use separate ITK Git tags for C++ and Python CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: v5.0.0
-  ITKPythonPost: '.post1'
+  ITKGitTag: 'v5.0.0'
+  ITKPythonGitTag: 'v5.0.0.post1'
   CMakeBuildType: Release
 
 trigger:
@@ -174,8 +174,7 @@ jobs:
 
   - script: |
       cd $(Agent.BuildDirectory)/ITKModuleTemplate
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       $(Build.SourcesDirectory)/dockcross-manylinux-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -205,7 +204,7 @@ jobs:
 
   - script: |
       cd $(Agent.BuildDirectory)/ITKModuleTemplate
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       $(Build.SourcesDirectory)/macpython-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -235,7 +234,7 @@ jobs:
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       cd $(Agent.BuildDirectory)\ITKModuleTemplate
-      set ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe
       powershell.exe -file $(Build.SourcesDirectory)\windows-download-cache-and-build-module-wheels.ps1

--- a/{{cookiecutter.project_name}}/test/azure-pipelines.yml
+++ b/{{cookiecutter.project_name}}/test/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: v5.0.0
-  ITKPythonPost: '.post1'
+  ITKGitTag: 'v5.0.0'
+  ITKPythonGitTag: 'v5.0.0.post1'
   CMakeBuildType: Release
 
 trigger:
@@ -157,7 +157,7 @@ jobs:
     displayName: 'Fetch build script'
 
   - script: |
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       ./dockcross-manylinux-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -181,7 +181,7 @@ jobs:
     displayName: 'Fetch build script'
 
   - script: |
-      export ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      export ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       ./macpython-download-cache-and-build-module-wheels.sh
     displayName: 'Build Python packages'
 
@@ -205,7 +205,7 @@ jobs:
 
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-      set ITK_PACKAGE_VERSION=$(ITKGitTag)$(ITKPythonPost)
+      set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe
       powershell.exe -file .\windows-download-cache-and-build-module-wheels.ps1


### PR DESCRIPTION
By separating the tags, we can use different versions of ITK for C++ and Python builds. In this way, we can use, for example, a Git commit hash for the C++ version, and an unrelated tag name for the Python version.

@jhlegarreta since the testing macro *ITK_* prefix came in after v5.0.0 was tagged, with this change, we can set  *ITKGitTag* to a later version of ITK Git *master* and keep *ITKPythonGitTag* to *v5.0.0.post1*.