### PR TITLE
BUG: Remove quotes from ITK version in Azure configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: 'v5.0.0'
-  ITKPythonGitTag: 'v5.0.0.post1'
+  ITKGitTag: v5.0.0
+  ITKPythonGitTag: v5.0.0.post1
   CMakeBuildType: Release
 
 trigger:

--- a/{{cookiecutter.project_name}}/test/azure-pipelines.yml
+++ b/{{cookiecutter.project_name}}/test/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  ITKGitTag: 'v5.0.0'
-  ITKPythonGitTag: 'v5.0.0.post1'
+  ITKGitTag: v5.0.0
+  ITKPythonGitTag: v5.0.0.post1
   CMakeBuildType: Release
 
 trigger:


### PR DESCRIPTION
These are optional and they interfere with the ITK/Utilities/Maintenance/UpdateRequiredITKVersionInRemoteModules.sh
script.