### PR TITLE
ENH: Support arbitrary ITK version for C++ CI testing

### DIFF
--- a/{{cookiecutter.project_name}}/test/azure-pipelines.yml
+++ b/{{cookiecutter.project_name}}/test/azure-pipelines.yml
@@ -58,7 +58,9 @@ jobs:
     displayName: 'Install build dependencies'
 
   - script: |
-      git clone --depth 5 --branch $(ITKGitTag) https://github.com/InsightSoftwareConsortium/ITK.git
+      git clone https://github.com/InsightSoftwareConsortium/ITK.git
+      cd ITK
+      git checkout $(ITKGitTag)
     workingDirectory: $(Agent.BuildDirectory)
     displayName: 'Download ITK'
 


### PR DESCRIPTION
So we can choose an arbitrary ITK Git hash to build a given remote
module against.