### PR TITLE
ENH: Add Visual Studio toolset version to CI configuration

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,7 +33,7 @@ jobs:
         imageName: 'windows-2019'
         cCompiler: cl.exe
         cxxCompiler: cl.exe
-        compilerInitialization: 'call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"'
+        compilerInitialization: 'call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2'
 
   pool:
     vmImage: $(imageName)
@@ -233,7 +233,7 @@ jobs:
     displayName: 'Evaluate template'
 
   - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2
       cd $(Agent.BuildDirectory)\ITKModuleTemplate
       set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe

--- a/{{cookiecutter.project_name}}/test/azure-pipelines.yml
+++ b/{{cookiecutter.project_name}}/test/azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
         imageName: 'windows-2019'
         cCompiler: cl.exe
         cxxCompiler: cl.exe
-        compilerInitialization: 'call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"'
+        compilerInitialization: 'call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2'
 
   pool:
     vmImage: $(imageName)
@@ -206,7 +206,7 @@ jobs:
     displayName: 'Fetch build script'
 
   - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat" -vcvars_ver=14.2
       set ITK_PACKAGE_VERSION=$(ITKPythonGitTag)
       set CC=cl.exe
       set CXX=cl.exe


### PR DESCRIPTION
Enable a consistent toolchain for binary compatilibilty with the ITK Python Builds created
with the 5.1 release and remote module Python packages.