### PR TITLE
BUG: Add --no-clean flag to Windows Python package generation step

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -228,7 +228,7 @@ jobs:
         set PATH="C:\P\grep;%PATH%"
         set CC=cl.exe
         set CXX=cl.exe
-        C:\Python3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64"
+        C:\Python3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ "{{" }} matrix.python-version-minor {{ "}}" }}-x64" --no-cleanup
 
     - name: Publish Python package as GitHub Artifact
       uses: actions/upload-artifact@v1


### PR DESCRIPTION
In CI, this is unnecessary now because every Python package version is
generated in a clean virtual machine instance. On some packages that use
CMake FetchContent, the cleanup step can fail with:

  Adding 'itk_elastix-0.6.0.dist-info/RECORD'
  removing _skbuild\win-amd64-3.5\setuptools\bdist.win-amd64\wheel
  C:\P\IPP\venv-35-x64\lib\site-packages\wheel\pep425tags.py:82: RuntimeWarning: Config variable 'Py_DEBUG' is unset, Python ABI tag may be incorrect
    warn=(impl == 'cp')):
  C:\P\IPP\venv-35-x64\lib\site-packages\wheel\pep425tags.py:87: RuntimeWarning: Config variable 'WITH_PYMALLOC' is unset, Python ABI tag may be incorrect
    sys.version_info < (3, 8))) \
  running clean
  removing '_skbuild\win-amd64-3.5\cmake-install'
  removing '_skbuild\win-amd64-3.5\cmake-build'
  error: [WinError 5] Access is denied: '_skbuild\\win-amd64-3.5\\cmake-build\\_deps\\elx-src\\.git\\objects\\pack\\pack-fe0f18355ee7166ea63b5deefec6fde96d8691fc.idx'
  SCRIPT_DIR: C:\P\IPP\scripts
  ROOT_DIR: D:\a\im