### PR TITLE
BUG: Fix 404 Error in License Badge Link

### DIFF
--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -9,7 +9,7 @@
     :alt: PyPI Version
 
 .. image:: https://img.shields.io/badge/License-Apache%202.0-blue.svg
-    :target: {{ cookiecutter.download_url }}/blob/master/LICENSE)
+    :target: {{ cookiecutter.download_url }}/blob/master/LICENSE
     :alt: License
 
 Overview


### PR DESCRIPTION
An extraneous end parenthesis has been removed, which was resulting
in a 404 error when trying to access the LICENSE file via the badge.