### PR TITLE
BUG: Build Python packages against v5.1.0.post2

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -137,7 +137,7 @@ jobs:
       matrix:
         python-version: [35, 36, 37, 38]
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -181,7 +181,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -218,7 +218,7 @@ jobs:
       matrix:
         python-version-minor: [5, 6, 7, 8]
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -130,7 +130,7 @@ jobs:
       matrix:
         python-version: [35, 36, 37, 38]
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -166,7 +166,7 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2
@@ -195,7 +195,7 @@ jobs:
       matrix:
         python-version-minor: [5, 6, 7, 8]
         include:
-          - itk-python-git-tag: "v5.1.0"
+          - itk-python-git-tag: "v5.1.0.post2"
 
     steps:
     - uses: actions/checkout@v2

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -44,6 +44,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.0.0.post1'
+        r'itk>=5.1.0.post2'
     ]
     )


### PR DESCRIPTION
Adds package improvements. All remote modules should update their CI to
build against itk v5.1.0.post2 and their setup.py dependency to
itk>=5.1.0.post2