### PR TITLE
ENH: update minimum Python version from 3.5 to 3.6

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -135,7 +135,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38]
         include:
           - itk-python-git-tag: "v5.1.1"
 
@@ -216,7 +216,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [5, 6, 7, 8]
+        python-version-minor: [6, 7, 8]
         include:
           - itk-python-git-tag: "v5.1.1"
 

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [35, 36, 37, 38]
+        python-version: [36, 37, 38]
         include:
           - itk-python-git-tag: "v5.1.1"
 
@@ -193,7 +193,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [5, 6, 7, 8]
+        python-version-minor: [6, 7, 8]
         include:
           - itk-python-git-tag: "v5.1.1"
 

--- a/{{cookiecutter.project_name}}/setup.py
+++ b/{{cookiecutter.project_name}}/setup.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from os import sys
 
 try:
@@ -44,6 +43,6 @@ setup(
     keywords='ITK InsightToolkit',
     url=r'https://itk.org/',
     install_requires=[
-        r'itk>=5.1.0.post3'
+        r'itk>=5.1.1'
     ]
     )


### PR DESCRIPTION
Python 3.6 is now minimum. Version 3.5 has reached end of life.