### PR TITLE
Add ITK runtime directory in PATH for Windows

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -107,6 +107,9 @@ jobs:
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ matrix.c-compiler }})
         set(ENV{CXX} ${{ matrix.cxx-compiler }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
         BUILD_TESTING:BOOL=ON

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -100,6 +100,9 @@ jobs:
         set(dashboard_no_clean 1)
         set(ENV{CC} ${{ "{{" }} matrix.c-compiler {{ "}}" }})
         set(ENV{CXX} ${{ "{{" }} matrix.cxx-compiler {{ "}}" }})
+        if(WIN32)
+          set(ENV{PATH} "\${CTEST_DASHBOARD_ROOT}/ITK-build/bin;\$ENV{PATH}")
+        endif()
         set(dashboard_cache "
         ITK_DIR:PATH=\${CTEST_DASHBOARD_ROOT}/ITK-build
         BUILD_TESTING:BOOL=ON


### PR DESCRIPTION
This PR adds ITK runtime directory in PATH for Windows. The commit 1ad4cfbe033c2016bbdceb511f4694746cac70d4 adresses the problem discussed [here](https://discourse.itk.org/t/io-dlls-not-found/3464). It is not clear to me if this is a good solution, if this should be put in the cmd shell part of the yml file (I tried but it failed, see SimonRit/RTK@6373cb5a8ffa3f7d0a66912306a10e3ee07fa4f2), or if this should be addressed in RTK CMakeLists.txt... Let me know what you think.
cc @LucasGandel