### PR TITLE
COMP: Use CMake 3.18.3

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -192,6 +192,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
     - name: Get specific of CMake, Ninja
       uses: lukka/get-cmake@v3.18.3
 

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -40,6 +40,9 @@ jobs:
         python -m pip install ninja
         python -m pip install cookiecutter
 
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: Download ITK
       run: |
         cd ..
@@ -189,6 +192,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: 'Fetch build script'
       run: |
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
@@ -235,6 +241,9 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: '3.x'
+
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: Evaluate template
       shell: bash

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -39,6 +39,9 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install ninja
 
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: Download ITK
       run: |
         cd ..
@@ -174,6 +177,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: 'Fetch build script'
       run: |
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/macpython-download-cache-and-build-module-wheels.sh -O
@@ -201,6 +207,9 @@ jobs:
           - itk-python-git-tag: "v5.1.2"
 
     steps:
+    - name: Get specific of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - uses: actions/checkout@v2
       with:
         path: "im"

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -177,6 +177,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
     - name: Get specific of CMake, Ninja
       uses: lukka/get-cmake@v3.18.3
 


### PR DESCRIPTION
Work around a regression in CMake 3.19.1 causing configuration errors:

  CMake Error: install(EXPORT "ITKTargets" ...) includes target "gdcmjpeg8"

xref: https://gitlab.kitware.com/cmake/cmake/-/issues/21529

Install CMake 3.18.3.