### PR TITLE
BUG: Do not use shallow version of checkout for clang format linting

### DIFF
--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -8,6 +8,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/{{cookiecutter.project_name}}/.github/workflows/clang-format-linter.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/clang-format-linter.yml
@@ -8,6 +8,5 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master


### PR DESCRIPTION
Recent checks fail to checkout the required commit.
