### PR TITLE
ENH: Improve Github Actions badge to include target

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 ITKModuleTemplate
 =================
 
-![](https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/workflows/Build,%20test,%20package/badge.svg)
+[![][gha-img]][gha-link]
+
+[gha-img]: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/workflows/build-test-package.yml/badge.svg)
+[gha-link]: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/workflows/build-test-package.yml
+
 
 Overview
 --------

--- a/{{cookiecutter.project_name}}/README.rst
+++ b/{{cookiecutter.project_name}}/README.rst
@@ -1,8 +1,9 @@
 {{ cookiecutter.project_name }}
 =================================
 
-.. image:: {{ cookiecutter.download_url }}/workflows/Build,%20test,%20package/badge.svg
-    :alt:    Build Status
+.. image:: {{ cookiecutter.download_url }}/actions/workflows/build-test-package.yml/badge.svg
+    :target: {{ cookiecutter.download_url }}/actions/workflows/build-test-package.yml
+    :alt: Build Status
 
 .. image:: https://img.shields.io/pypi/v/{{ cookiecutter.python_package_name }}.svg
     :target: https://pypi.python.org/pypi/{{ cookiecutter.python_package_name }}


### PR DESCRIPTION
Include target for the GitHub Actions badge associated with the `README` of both the `ITKModuleTemplate` project and the cookiecutter template.

For future reference, URLs for both the badge image and the associated target where obtained like this:

![image](https://user-images.githubusercontent.com/219043/151448601-ac93c1d6-52b2-4797-a476-01ae8e502dff.png)

`