### PR TITLE
BUG: Fix rendering of badge in top-level README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ITKModuleTemplate
 
 [![][gha-img]][gha-link]
 
-[gha-img]: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/workflows/build-test-package.yml/badge.svg)
+[gha-img]: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/workflows/build-test-package.yml/badge.svg
 [gha-link]: https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/workflows/build-test-package.yml
 
 


### PR DESCRIPTION
This commit fixes regression introduced in b254407 (ENH: Improve Github
Actions badge to include target) removing extraneous parenthesis.