### PR TITLE
ENH: Use https instead of http when https works

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,7 +3,7 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "801370c025c7d296783481779a41c6d559c992c5"
+  itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
   itk-wheel-tag: "v5.3rc04"
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ITKModuleTemplate
 Overview
 --------
 
-This is a module for the [Insight Toolkit (ITK)](http://itk.org) for
+This is a module for the [Insight Toolkit (ITK)](https://itk.org) for
 segmentation and registration. It is designed to work with the ITK
 modular system.
 
@@ -88,7 +88,7 @@ associated repository, then add
 Remote Module
 -------------
 
-After an [Insight Journal](http://www.insight-journal.org/) article has
+After an [Insight Journal](https://www.insight-journal.org/) article has
 been submitted, the module can be included in ITK as a [remote
 module](https://itk.org/ITKSoftwareGuide/html/Book1/ITKSoftwareGuide-Book1ch9.html#x55-1640009.7).
 Add a file in "ITK/Modules/Remote" called "YourModule.remote.cmake", for
@@ -97,7 +97,7 @@ followlowing contents:
 
     itk_fetch_module(MyModule
       "A description of the a module."
-      GIT_REPOSITORY http://github.com/myuser/ITKMyModule.git
+      GIT_REPOSITORY https://github.com/myuser/ITKMyModule.git
       GIT_TAG abcdef012345
       )
 

--- a/{{cookiecutter.project_name}}/.clang-format
+++ b/{{cookiecutter.project_name}}/.clang-format
@@ -4,7 +4,7 @@
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
 ##
 ## The clang-format binaries can be downloaded as part of the clang binary distributions
-## from http://releases.llvm.org/download.html
+## from https://releases.llvm.org/download.html
 ##
 ## Use the script Utilities/Maintenance/clang-format.bash to faciliate
 ## maintaining a consistent code style.

--- a/{{cookiecutter.project_name}}/.editorconfig
+++ b/{{cookiecutter.project_name}}/.editorconfig
@@ -1,4 +1,4 @@
-# http://EditorConfig.org
+# https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -3,7 +3,7 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "801370c025c7d296783481779a41c6d559c992c5"
+  itk-git-tag: "d6acfd26bfcdec606d605beb1301bddfb17c05a6"
   itk-wheel-tag: "v5.3rc04"
 
 jobs:

--- a/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
+++ b/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
@@ -40,7 +40,7 @@ namespace Statistics
  * where \f$a\f$ is the Multiplier \f$c\f$ is the Increment and \f$m\f$ is
  * the Modulus.
  *
- * http://en.wikipedia.com/wiki/Linear_congruential_generator
+ * https://en.wikipedia.com/wiki/Linear_congruential_generator
  *
  * The random numbers generated have a period \f$m\f$.
  *

--- a/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
+++ b/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.hxx
+++ b/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.hxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/{{cookiecutter.project_name}}/src/itkMinimalStandardRandomVariateGenerator.cxx
+++ b/{{cookiecutter.project_name}}/src/itkMinimalStandardRandomVariateGenerator.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/{{cookiecutter.project_name}}/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
+++ b/{{cookiecutter.project_name}}/test/itkMinimalStandardRandomVariateGeneratorTest.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,

--- a/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
+++ b/{{cookiecutter.project_name}}/test/itk{{cookiecutter.filter_name}}Test.cxx
@@ -6,7 +6,7 @@
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *         https://www.apache.org/licenses/LICENSE-2.0.txt
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
https is more tamper-resistant and more private so we use it instead
of http when it is available.

Following
https://github.com/InsightSoftwareConsortium/ITK/pull/3428/commits/9cd0f2053f0cf181ec4412bf896301faf0cc2092

Bump the ITK commit hash so that the above changes are accepted by the
ITK style checker.