### PR TITLE
ENH: Switch Github Actions macOS environment

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         include:
           - os: ubuntu-20.04
             c-compiler: "gcc"
@@ -22,7 +22,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-10.15
+          - os: macos-11
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
@@ -186,7 +186,7 @@ jobs:
         path: Evaluated/ITKModuleTemplate/dist
 
   build-macos-python-packages:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       max-parallel: 2
 

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 3
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
         include:
           - os: ubuntu-20.04
             c-compiler: "gcc"
@@ -22,7 +22,7 @@ jobs:
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
             cmake-build-type: "Release"
-          - os: macos-10.15
+          - os: macos-11
             c-compiler: "clang"
             cxx-compiler: "clang++"
             cmake-build-type: "MinSizeRel"
@@ -166,7 +166,7 @@ jobs:
         path: dist
 
   build-macos-python-packages:
-    runs-on: macos-10.15
+    runs-on: macos-11
     strategy:
       max-parallel: 2
 


### PR DESCRIPTION
Switch Github Actions macOS environment version to `macos-11`.

`macOS-10.15` is being deprecated and supported will end by 8/30/2022:
https://github.com/actions/virtual-environments/issues/5583

Related to recent warnings in the Azure Pipelines macOS environment
being used in the main ITK repository:
https://github.com/InsightSoftwareConsortium/ITK/pull/3532/commits/e5595dee1917e94ecc3c7f94873841b0f522d3c0