### PR TITLE
ENH: Specify the same CMake version for Linux Python package builds

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -161,6 +161,9 @@ jobs:
       with:
         python-version: 3.8
 
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: Evaluate template
       shell: bash
       run: |

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -149,6 +149,9 @@ jobs:
         sudo rm -rf "$AGENT_TOOLSDIRECTORY"
         df -h
 
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - name: 'Fetch build script'
       run: |
         curl -L https://raw.githubusercontent.com/InsightSoftwareConsortium/ITKPythonPackage/master/scripts/dockcross-manylinux-download-cache-and-build-module-wheels.sh -O


### PR DESCRIPTION
As Linux comes with some version of CMake,
this problem sneaked in without detection.
If CMake version is important, this difference
between version on different OSes can be confusing.