### PR TITLE
ENH: Versions as strings, not numbers, so that 3.1 != 3.10, etc.

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Install build dependencies
       run: |
@@ -142,7 +142,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [37, 38, 39, 310]
+        python-version: ["37", "38", "39", "310"]
 
     steps:
     - uses: actions/checkout@v2
@@ -159,7 +159,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Get specific version of CMake, Ninja
       uses: lukka/get-cmake@v3.18.3
@@ -215,7 +215,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Evaluate template
       shell: bash
@@ -242,7 +242,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [7, 8, 9, 10]
+        python-version-minor: ["7", "8", "9", "10"]
 
     steps:
     - uses: actions/checkout@v2
@@ -263,7 +263,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Evaluate template
       shell: bash

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: "3.8"
 
     - name: Install build dependencies
       run: |
@@ -135,7 +135,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version: [37, 38, 39, 310]
+        python-version: ["37", "38", "39", "310"]
 
     steps:
     - uses: actions/checkout@v2
@@ -209,7 +209,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        python-version-minor: [7, 8, 9, 10]
+        python-version-minor: ["7", "8", "9", "10"]
 
     steps:
     - name: Get specific version of CMake, Ninja


### PR DESCRIPTION
Re-write versions as strings rather than numbers because 3.1 != 3.10, etc.  Nothing is broken at present but in the future as, e.g., the Python version for some things goes from 3.8 to 3.9 to 3.10, this could end up being an unexpected problem.