### PR TITLE
ENH: Upgrade GitHub actions to `checkout@v3` and `setup-python@v3`

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -29,10 +29,10 @@ jobs:
             cmake-build-type: "MinSizeRel"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: "3.8"
 
@@ -146,7 +146,7 @@ jobs:
         python-version: ["37", "38", "39", "310", "311"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Free up disk space'
       run: |
@@ -164,7 +164,7 @@ jobs:
         unzstd --version
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: "3.8"
 
@@ -207,7 +207,7 @@ jobs:
       max-parallel: 2
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Specific XCode version'
       run: |
@@ -222,7 +222,7 @@ jobs:
         chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: "3.8"
 
@@ -255,7 +255,7 @@ jobs:
         python-version-minor: ["7", "8", "9", "10", "11"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: 'Install Python'
       run: |
@@ -263,7 +263,7 @@ jobs:
         $pythonVersion = "3.${{ matrix.python-version-minor }}"
         iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v3
       with:
         python-version: '3.x'
 
@@ -271,7 +271,7 @@ jobs:
       uses: lukka/get-cmake@v3.22.2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: "3.8"
 

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/{{cookiecutter.project_name}}/.github/workflows/clang-format-linter.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/clang-format-linter.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master


### PR DESCRIPTION
Fix `Node.js` warnings linked to GitHub actions: upgrade to
`actions/checkout@v3` and `actions/setup-python@v3`.

Fixes:
```
cov / build (3.9, ubuntu-latest, pip)
Node.js 12 actions are deprecated.
For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16:
actions/checkout@v2, actions/setup-python@v2
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/runs/3594726041

Fixes issue #141  (replaces #144)