### PR TITLE
ENH: Fix workflow actions warnings linked to `Node.js`

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
@@ -43,7 +43,7 @@ jobs:
         python -m pip install cookiecutter
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: Download ITK
       run: |
@@ -164,12 +164,12 @@ jobs:
         unzstd --version
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: Evaluate template
       shell: bash
@@ -196,7 +196,7 @@ jobs:
         done
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: LinuxWheel${{ matrix.python-version }}
         path: Evaluated/ITKModuleTemplate/dist
@@ -214,7 +214,7 @@ jobs:
         sudo xcode-select -s "/Applications/Xcode_13.2.1.app"
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: 'Fetch build script'
       run: |
@@ -222,7 +222,7 @@ jobs:
         chmod u+x macpython-download-cache-and-build-module-wheels.sh
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
@@ -242,7 +242,7 @@ jobs:
         ../../macpython-download-cache-and-build-module-wheels.sh
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: MacOSWheels
         path: Evaluated/ITKModuleTemplate/dist
@@ -263,15 +263,15 @@ jobs:
         $pythonVersion = "3.${{ matrix.python-version-minor }}"
         iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/scikit-build/scikit-ci-addons/master/windows/install-python.ps1'))
 
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.x'
 
     - name: Get specific version of CMake, Ninja
-      uses: lukka/get-cmake@v3.22.2
+      uses: lukka/get-cmake@v3.24.2
 
     - name: Set up Python 3.8
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.8"
 
@@ -313,7 +313,7 @@ jobs:
         C:\Python3${{ matrix.python-version-minor }}-x64\python.exe C:\P\IPP\scripts\windows_build_module_wheels.py --py-envs "3${{ matrix.python-version-minor }}-x64"
 
     - name: Publish Python package as GitHub Artifact
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v3
       with:
         name: WindowWheel3.${{ matrix.python-version-minor }}
         path: Evaluated/ITKModuleTemplate/dist


### PR DESCRIPTION
Fix workflow actions warnings linked to `Node.js: bump miscellaneous GitHub actions versions in workflow.

Fixes:
```
build-test-cxx (windows-2022)
Node.js 12 actions are deprecated. For more information see:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: lukka/get-cmake@v3.22.2
```

and
```
build-test-cxx (windows-2022)
The `set-output` command is deprecated and will be disabled soon.
Please upgrade to using Environment Files. For more information see:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

raised for example in:
https://github.com/InsightSoftwareConsortium/ITKModuleTemplate/actions/runs/3669019278

Left behind in 2c1a717.