### PR TITLE
ENH: Specify Python versions for macOS CI builds

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -205,6 +205,8 @@ jobs:
     runs-on: macos-11
     strategy:
       max-parallel: 2
+      matrix:
+        python-version: ["38", "39", "310", "311"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Specify Python versions for macOS CI builds.