### PR TITLE
ENH: Use itkOverrideGetNameOfClassMacro as per ITK PR 4373

### DIFF
--- a/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
+++ b/{{cookiecutter.project_name}}/include/itkMinimalStandardRandomVariateGenerator.h
@@ -66,7 +66,7 @@ public:
   using NormalGeneratorType = itk::Statistics::NormalVariateGenerator;
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(MinimalStandardRandomVariateGenerator, RandomVariateGeneratorBase);
+  itkOverrideGetNameOfClassMacro(MinimalStandardRandomVariateGenerator);
 
   /** Method for creation through the object factory.  */
   itkNewMacro(Self);

--- a/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
+++ b/{{cookiecutter.project_name}}/include/itk{{cookiecutter.filter_name}}.h
@@ -54,7 +54,7 @@ public:
   using ConstPointer = SmartPointer<const Self>;
 
   /** Run-time type information. */
-  itkTypeMacro({{ cookiecutter.filter_name }}, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro({{ cookiecutter.filter_name }});
 
   /** Standard New macro. */
   itkNewMacro(Self);


### PR DESCRIPTION
See related ITK PRs:
https://github.com/InsightSoftwareConsortium/ITK/pull/4373
https://github.com/InsightSoftwareConsortium/ITK/pull/4378

We should probably wait until ITK 5.4 final is tagged, before merging this.