### PR TITLE
ENH: Updates for ITK 5.4.0

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -3,9 +3,9 @@ name: Build, test, package
 on: [push,pull_request]
 
 env:
-  itk-git-tag: "v5.4rc04"
-  itk-wheel-tag: "v5.4rc04"
-  itk-python-package-tag: "v5.4rc04"
+  itk-git-tag: "v5.4.0"
+  itk-wheel-tag: "v5.4.0"
+  itk-python-package-tag: "v5.4.0"
 
 jobs:
   build-test-cxx:

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -4,9 +4,9 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@df1df6398389fa1a99d169b1264b9647d2164dd0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@df1df6398389fa1a99d169b1264b9647d2164dd0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
     secrets:
       pypi_password: ${{ "{{" }} secrets.pypi_password {{ "}}" }}

--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 requires-python = ">=3.8"
 dependencies = [
-    "itk>=5.4rc4",
+    "itk == 5.4.*",
 ]
 
 [project.urls]


### PR DESCRIPTION
Update CI to build against v5.4.0

Also, improve how the `itk` python package version dependency is
specified. Uses `== 5.4.*` to indicated compatibility with 5.4.0, 5.4.1,
5.4.2, etc., but not 5.5.0, etc. There is generally binary
incompatibilty between minor versions. While it is possible that there
could be binary incompatibility between patch releases, it is more
likely that they will be compatible. This flexibilty helps ensure
that remote module packages are not assumed invalid when a new patch
version of `itk` is released. Addresses #142
