### PR TITLE
BUG: Prevent duplicate builds on pull request, push

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -11,7 +11,8 @@ on:
 env:
   itk-git-tag: "v5.4.0"
   itk-wheel-tag: "v5.4.0"
-  itk-python-package-tag: "v5.4.0"
+  # v5.4.0 + fixes
+  itk-python-package-tag: "a52d9b596b4f0da5ddb770ee99851e5c65ca3053"
 
 jobs:
   build-test-cxx:

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,6 +1,12 @@
 name: Build, test, package
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 env:
   itk-git-tag: "v5.4.0"

--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -1,6 +1,12 @@
 name: Build, test, package
 
-on: [push,pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   cxx-build-workflow:


### PR DESCRIPTION
When a branch is pushed to the same repository, i.e. not a fork, and a
pull request is made, duplicate builds will be generated for both the
pull request and push. Instead, only generate builds for pull requests
against main and pushes to main.
