### PR TITLE
BUG: Build python packages on tags for deployment

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/build-test-package.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
As a follow-up, we need to build on tags to deploy to PyPI.